### PR TITLE
106 fix the link launch in jupyterhub

### DIFF
--- a/HDA/DestinE_Digital_Twins/ClimateDT-ExtractLocationValues.ipynb
+++ b/HDA/DestinE_Digital_Twins/ClimateDT-ExtractLocationValues.ipynb
@@ -15,7 +15,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/ClimateDT-ParameterPlotter.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/ClimateDT-ParameterPlotter.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/ClimateDT-ParameterPlotter.ipynb
+++ b/HDA/DestinE_Digital_Twins/ClimateDT-ParameterPlotter.ipynb
@@ -17,7 +17,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/ClimateDT-ParameterPlotter.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/ClimateDT-ParameterPlotter.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE-Series.ipynb
+++ b/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE-Series.ipynb
@@ -16,7 +16,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE-Series.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE-Series.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE.ipynb
+++ b/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE.ipynb
@@ -16,7 +16,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_CLIMATE.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES-Series.ipynb
+++ b/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES-Series.ipynb
@@ -16,7 +16,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES-Series.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES-Series.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES.ipynb
+++ b/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES.ipynb
@@ -16,7 +16,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/DEDL-HDA-EO.ECMWF.DAT.DT_EXTREMES.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/ExtremeDT-ParameterPlotter.ipynb
+++ b/HDA/DestinE_Digital_Twins/ExtremeDT-ParameterPlotter.ipynb
@@ -17,7 +17,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/ExtremeDT-ParameterPlotter.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/ExtremeDT-ParameterPlotter.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"

--- a/HDA/DestinE_Digital_Twins/ExtremeDT-dataAvailability.ipynb
+++ b/HDA/DestinE_Digital_Twins/ExtremeDT-dataAvailability.ipynb
@@ -17,7 +17,7 @@
     "copyright: \"© 2025 EUMETSAT\"\n",
     "---\n",
     "<div style=\"margin: 6px 0;\">\n",
-    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE%20Digital%20Twins/ExtremeDT-dataAvailability.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
+    "  <a href=\"https://jupyter.central.data.destination-earth.eu/user-redirect/lab/tree/DestinE-DataLake-Lab/HDA/DestinE_Digital_Twins/ExtremeDT-dataAvailability.ipynb\" target=\"_blank\" style=\"text-decoration: none;\">\n",
     "    <span class=\"launch\">🚀 Launch in JupyterHub</span>\n",
     "  </a>\n",
     "</div>"


### PR DESCRIPTION
Link "launch in Jupyterhub" updated to take in consideration the new name of the folder :  (from DestinE Digital Twins → DestinE_Digital_Twins)