### PR TITLE
Add HDA dataset discovery notebook (STAC API CQL2 filtering)

### DIFF
--- a/HDA/PySTAC/Data-Discovery/HDA-Dataset-Discovery-STAC-API-Filter-Extension.ipynb
+++ b/HDA/PySTAC/Data-Discovery/HDA-Dataset-Discovery-STAC-API-Filter-Extension.ipynb
@@ -1,0 +1,793 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "frontmatter",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: \"Filtering datasets with the STAC API Filter extension (CQL2)\" \n",
+    "subtitle: \"This notebook shows how to use CQL2 filters, defined by the STAC API Filter extension, to find datasets in the DestinE Data Lake (HDA).\n",
+    "\"\n",
+    "author: \"Author: Alejandro Fonseca (EUMETSAT/Starion)\"\n",
+    "tags: [HDA,STAC,CQL2]\n",
+    "thumbnail: img/EUMETSAT_TEST.png \n",
+    "license: MIT\n",
+    "copyright: \"© 2024 EUMETSAT\"\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "contents",
+   "metadata": {},
+   "source": [
+    "### Contents\n",
+    "\n",
+    "- **Objective:** Learn to write CQL2 filters (STAC API Filter extension) to discover datasets in the HDA catalog, going step by step from an exact ID lookup to a combined, multi-condition search.\n",
+    "- **Data sources:** The DEDL Harmonised Data Access (HDA) STAC API v2: `https://hda.data.destination-earth.eu/stac/v2`. \n",
+    "- **Methods:** Each section introduces one CQL2 operator: `=`, `LIKE`, `CASEI()`, `IN`, `AND`/`OR`/`NOT`, fields beyond `id`/`title`, and the JSON encoding (`cql2-json`).\n",
+    "- **Prerequisites:** Only the `pystac-client` package. Dataset discovery does not require authentication or a DESP account.\n",
+    "- **Expected output:** Printed lists of collection IDs and titles matching each filter, ending with a single collection found by combining operators."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "what-is-filter",
+   "metadata": {},
+   "source": [
+    "## What is the Filter extension?\n",
+    "\n",
+    "The [STAC API Filter extension](https://github.com/stac-api-extensions/filter) adds a `filter` parameter to STAC search requests. The idea is familiar from SQL: the filter is a condition, like a `WHERE` clause, that every returned record must satisfy.\n",
+    "\n",
+    "The condition is written in **CQL2** (Common Query Language), a small standard language with two equivalent encodings:\n",
+    "\n",
+    "- `cql2-text` : a readable string, e.g. `id = 'EO.EUM.DAT.METOP.GLB-SST-NC'`\n",
+    "- `cql2-json` : the same condition as a JSON document, convenient when the filter is built by code\n",
+    "\n",
+    "In HDA the `filter` parameter is used here for **collection search**: the catalog has 300+ collections and CQL2 narrows them down precisely. `pystac-client` handles the encoding: pass the filter as a string and it is sent as `cql2-text` automatically.\n",
+    "\n",
+    "> **Note:** the Filter extension also applies to item search (`/search`). In HDA that support is currently partial, so this notebook focuses on collection search. Item search is covered in [HDA-PyStac-Client.ipynb](../HDA-PyStac-Client.ipynb).\n",
+    "\n",
+    "The goal of discovery is always the same: find the **collection ID**. With CQL2 there are several ways to get it, depending on what you already know. Each cell below shows one strategy, from the most precise to the most open; the following sections explain each operator in detail."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "imports-md",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6d4e84cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "pip install --user --quiet --upgrade destinelab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "imports-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pystac_client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "connect-md",
+   "metadata": {},
+   "source": [
+    "## Connect to the HDA catalog\n",
+    "\n",
+    "No token or credentials are needed for discovery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "connect-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to: DEDL HDA STAC API\n"
+     ]
+    }
+   ],
+   "source": [
+    "HDA_STAC_URL = \"https://hda.data.destination-earth.eu/stac/v2\"\n",
+    "\n",
+    "catalog = pystac_client.Client.open(HDA_STAC_URL)\n",
+    "print(f\"Connected to: {catalog.title}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "helper-md",
+   "metadata": {},
+   "source": [
+    "Every example ends the same way: run the search and list the matching IDs and titles. A small helper avoids repeating those lines in each cell. It prints at most `limit` collections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "helper-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show(results, limit=10):\n",
+    "    print(f\"{len(results)} collections found\")\n",
+    "    for collection in results[:limit]:\n",
+    "        print(f\"  {collection.id}  —  {collection.title}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec2-md",
+   "metadata": {},
+   "source": [
+    "## 1. Searching the ID for part of the name using : `LIKE`\n",
+    "\n",
+    "Most of the time you do not know the full ID or just remember part of it. In that case you can use the operator `LIKE` that compares a field against a pattern, where `%` matches any sequence of characters. Where you place the `%` matters:\n",
+    "\n",
+    "- `'EO.EUM.DAT.MSG%'` : starts with : everything from one satellite dataset and provider\n",
+    "- `'%Temperature%'` : contains: the word appears anywhere\n",
+    "- `'AVHRR%'` : starts with : titles beginning with an instrument name\n",
+    "\n",
+    "HDA collection IDs follow the convention `EO.<PROVIDER>.DAT.<DATASET>`, so an anchored prefix is the natural way to select a provider or a satellite family. The first example selects the whole Meteosat Second Generation (MSG) family."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "sec2-code-id",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15 collections found\n",
+      "  EO.EUM.DAT.MSG.CLM  —  Cloud Mask - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.CLM-IODC  —  Cloud Mask - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.CTH  —  Cloud Top Height - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.CTH-IODC  —  Cloud Top Height - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.HRSEVIRI  —  High Rate SEVIRI Level 1.5 Image Data - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.HRSEVIRI-IODC  —  High Rate SEVIRI Level 1.5 Image Data - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.LSA-FRM  —  Fire Risk Map - Released Energy Based - MSG\n",
+      "  EO.EUM.DAT.MSG.LSA-LST-CDR  —  Land Surface Temperature Climate Data Record - MSG\n",
+      "  EO.EUM.DAT.MSG.LSA-LSTDE  —  Land Surface Temperature with Directional Effects - MSG\n",
+      "  EO.EUM.DAT.MSG.MSG15-RSS  —  Rapid Scan High Rate SEVIRI Level 1.5 Image Data - MSG\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = catalog.collection_search(filter=\"id LIKE 'EO.EUM.DAT.MSG%'\").collection_list()\n",
+    "show(results, limit=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sec2-code-title",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 collections found\n",
+      "  EO.EUM.DAT.METOP.AVHRDUAL0100  —  AVHRR Global (dual) Atmospheric Motion Vectors Climate Data Record Release 1 - Metop-A/B and -B/A\n",
+      "  EO.EUM.DAT.METOP.AVHRPWE0200  —  AVHRR Polar Atmospheric Motion Vectors Climate Data Record Release 2 - Metop-A and -B\n",
+      "  EO.EUM.DAT.METOP.AVHRRGACR02  —  AVHRR GAC Atmospheric Motion Vectors Climate Data Record Release 2 - Multimission - Polar\n",
+      "  EO.EUM.DAT.METOP.AVHRRL1  —  AVHRR Level 1B - Metop - Global\n",
+      "  EO.EUM.DAT.MULT.AVHGAC1C0100  —  AVHRR Fundamental Data Record - Release 1 - Multimission\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filtering for a key word in the title containing\n",
+    "results = catalog.collection_search(filter=\"title LIKE 'AVHRR%'\").collection_list()\n",
+    "show(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66bbcf19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 collections found\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_REP_OBSERVATIONS_010_024  —  ESA SST CCI and C3S reprocessed sea surface temperature analyses\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filtering for a key word in the title that starst with\n",
+    "results = catalog.collection_search(filter=\"title LIKE '%sea surface temperature%'\").collection_list()\n",
+    "show(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "bc0df057",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 collections found\n",
+      "  EO.EUM.DAT.METOP.GLB-SST-NC  —  Global L3C AVHRR Sea Surface Temperature (GHRSST) - Metop\n",
+      "  EO.MO.DAT.SST_GLO_SST_L3S_NRT_OBSERVATIONS_010_010  —  ODYSSEA Global Ocean - Sea Surface Temperature Multi-sensor L3 Observations\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_NRT_OBSERVATIONS_010_001  —  Global Ocean OSTIA Sea Surface Temperature and Sea Ice Analysis\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_REP_OBSERVATIONS_010_011  —  Global Ocean OSTIA Sea Surface Temperature and Sea Ice Reprocessed\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_REP_OBSERVATIONS_010_024  —  ESA SST CCI and C3S reprocessed sea surface temperature analyses\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You remember a fragment of the ID: substring search\n",
+    "results = catalog.collection_search(filter=\"id LIKE '%SST%'\").collection_list()\n",
+    "show(results, limit=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec3-md",
+   "metadata": {},
+   "source": [
+    "## 2. Using strings case-sensitive: `CASEI()`\n",
+    "\n",
+    "CQL2 string comparisons are case-sensitive, and HDA enforces this strictly: searching for `'%metop%'` in lowercase finds nothing,\n",
+    " because the titles say `Metop`. `CASEI()` (case-insensitive) solves this: it normalizes the casing of a value before comparing. \n",
+    " Wrap **both** sides (the property and the pattern) and the exact capitalization no longer matters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "sec3-code-ok",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "34 collections found\n",
+      "  EO.EUM.CM.METOP.ASCSZFR02  —  ASCAT Level 1 SZF Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZOR02  —  ASCAT Level 1 SZO Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZRR02  —  ASCAT Level 1 SZR Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.DAT.METOP.AMSUL1  —  AMSU-A Level 1B - Metop - Global\n",
+      "  EO.EUM.DAT.METOP.ASCSZF1B  —  ASCAT Level 1 Sigma0 Full Resolution - Metop - Global\n",
+      "  EO.EUM.DAT.METOP.ASCSZO1B  —  ASCAT Level 1 Sigma0 resampled at 25 km Swath Grid - Metop - Global\n",
+      "  EO.EUM.DAT.METOP.ASCSZR1B  —  ASCAT Level 1 Sigma0 resampled at 12.5 km Swath Grid - Metop - Global\n",
+      "  EO.EUM.DAT.METOP.AVHRDUAL0100  —  AVHRR Global (dual) Atmospheric Motion Vectors Climate Data Record Release 1 - Metop-A/B and -B/A\n",
+      "  EO.EUM.DAT.METOP.AVHRPWE0200  —  AVHRR Polar Atmospheric Motion Vectors Climate Data Record Release 2 - Metop-A and -B\n",
+      "  EO.EUM.DAT.METOP.AVHRRL1  —  AVHRR Level 1B - Metop - Global\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Filtering by using case-sensitive CASEI()\n",
+    "results = catalog.collection_search(filter=\"CASEI(title) LIKE CASEI('%metop%')\").collection_list()\n",
+    "show(results, limit=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "41fe2a3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7 collections found\n",
+      "  EO.EUM.DAT.METOP.GLB-SST-NC  —  Global L3C AVHRR Sea Surface Temperature (GHRSST) - Metop\n",
+      "  EO.EUM.DAT.SENTINEL-3.SL_2_WSTBC003  —  SLSTR Level 2 Sea Surface Temperature (SST) (version BC003) - Sentinel-3 - Reprocessed\n",
+      "  EO.EUM.DAT.SENTINEL-3.SL_2_WST___  —  SLSTR Level 2 Sea Surface Temperature (SST) - Sentinel-3\n",
+      "  EO.MO.DAT.SST_GLO_SST_L3S_NRT_OBSERVATIONS_010_010  —  ODYSSEA Global Ocean - Sea Surface Temperature Multi-sensor L3 Observations\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_NRT_OBSERVATIONS_010_001  —  Global Ocean OSTIA Sea Surface Temperature and Sea Ice Analysis\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_REP_OBSERVATIONS_010_011  —  Global Ocean OSTIA Sea Surface Temperature and Sea Ice Reprocessed\n",
+      "  EO.MO.DAT.SST_GLO_SST_L4_REP_OBSERVATIONS_010_024  —  ESA SST CCI and C3S reprocessed sea surface temperature analyses\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You only know the topic: search the title, ignoring the casing\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"CASEI(title) LIKE CASEI('%sea surface temperature%')\"\n",
+    ").collection_list()\n",
+    "show(results, limit=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec4-md",
+   "metadata": {},
+   "source": [
+    "## 3. Using a short list of candidates: `IN`\n",
+    "\n",
+    "When a few known IDs are of interest, `IN` retrieves them in a single request instead of one equality search per ID. Here: sea surface temperature and land surface temperature, both from Metop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "sec4-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 collections found\n",
+      "  EO.EUM.DAT.METOP.GLB-SST-NC  —  Global L3C AVHRR Sea Surface Temperature (GHRSST) - Metop\n",
+      "  EO.EUM.DAT.METOP.LSA-002  —  Daily Land Surface Temperature - Metop\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = catalog.collection_search(\n",
+    "    filter=\"id IN ('EO.EUM.DAT.METOP.GLB-SST-NC', 'EO.EUM.DAT.METOP.LSA-002')\"\n",
+    ").collection_list()\n",
+    "show(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-md",
+   "metadata": {},
+   "source": [
+    "## 4. Combining conditions: `AND`, `OR`, `NOT`\n",
+    "\n",
+    "Real searches usually mix criteria. The three logical operators behave as expected:\n",
+    "\n",
+    "- `AND` narrows: both conditions must hold\n",
+    "- `OR` widens: either condition may hold\n",
+    "- `NOT` excludes: the condition must not hold"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15f46f9d",
+   "metadata": {},
+   "source": [
+    "> **⚠️ Known limitation: mixing `AND` and `OR`:** the HDA server currently loses the\n",
+    "> grouping when a filter combines `AND` with a parenthesized `OR` group. The conditions\n",
+    "> are re-grouped following operator precedence (`AND` before `OR`), so part of the filter\n",
+    "> is silently not applied and unexpected collections appear in the results. This happens\n",
+    "> with both encodings, `cql2-text` and `cql2-json`.\n",
+    ">\n",
+    "> Until this is fixed, keep each filter as a pure `AND` chain (with `NOT` and `CASEI()`,\n",
+    "> which work fine), or run one query per `OR` branch and merge the results.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95d24543",
+   "metadata": {},
+   "source": [
+    "Filtering EUMETSAT collections whose title mentions climate (`AND`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "sec5-code-and",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "27 collections found\n",
+      "  EO.EUM.CM.METOP.ASCSZFR02  —  ASCAT Level 1 SZF Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZOR02  —  ASCAT Level 1 SZO Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZRR02  —  ASCAT Level 1 SZR Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.DAT.AMVR02  —  Atmospheric Motion Vectors Climate Data Record Release 2 - MFG and MSG - 0 degree\n",
+      "  EO.EUM.DAT.GSAL2R02  —  GSA Level 2 Climate Data Record Release 2 - MFG and MSG - 0 degree\n",
+      "  EO.EUM.DAT.METOP.AVHRDUAL0100  —  AVHRR Global (dual) Atmospheric Motion Vectors Climate Data Record Release 1 - Metop-A/B and -B/A\n",
+      "  EO.EUM.DAT.METOP.AVHRPWE0200  —  AVHRR Polar Atmospheric Motion Vectors Climate Data Record Release 2 - Metop-A and -B\n",
+      "  EO.EUM.DAT.METOP.AVHRRGACR02  —  AVHRR GAC Atmospheric Motion Vectors Climate Data Record Release 2 - Multimission - Polar\n",
+      "  EO.EUM.DAT.METOP.GOMPMA020100  —  Polar Multi-Sensor Aerosol Optical Properties Climate Data Record Release 1 - Metop-A and -B\n",
+      "  EO.EUM.DAT.METOP.IASSO22X0100  —  IASI SO2 Climate Data Record Release 1 - Metop-A and -B\n"
+     ]
+    }
+   ],
+   "source": [
+    "# using AND\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"id LIKE '%EUM%' AND title LIKE '%Climate%'\"\n",
+    ").collection_list()\n",
+    "show(results, limit=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-md-or",
+   "metadata": {},
+   "source": [
+    "Meteosat data from either the first (MFG) or the second generation (MSG) (`OR`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "sec5-code-or",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21 collections found\n",
+      "  EO.EUM.DAT.MFG.GSA-57  —  GSA Level 2 Climate Data Record Release 2 - MFG - 57 degree\n",
+      "  EO.EUM.DAT.MFG.GSA-63  —  GSA Level 2 Climate Data Record Release 2 - MFG - 63 degree\n",
+      "  EO.EUM.DAT.MFG.MFGAMV570IODC1  —  Atmospheric Motion Vectors Climate Data Record Release 1 - MFG - Indian Ocean 57 degrees E\n",
+      "  EO.EUM.DAT.MFG.MFGAMV630IODC1  —  Atmospheric Motion Vectors Climate Data Record Release 1 - MFG - Indian Ocean 63 degrees E\n",
+      "  EO.EUM.DAT.MFG.MTP15EASY0200_0DEG  —  MVIRI Level 1.5 Climate Data Record Release 2 - MFG - 0 degree\n",
+      "  EO.EUM.DAT.MFG.MTP15EASY0200_57DEG  —  MVIRI Level 1.5 Climate Data Record Release 2 - MFG - 57 degree\n",
+      "  EO.EUM.DAT.MSG.CLM  —  Cloud Mask - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.CLM-IODC  —  Cloud Mask - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.CTH  —  Cloud Top Height - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.CTH-IODC  —  Cloud Top Height - MSG - Indian Ocean\n"
+     ]
+    }
+   ],
+   "source": [
+    "# using OR\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"id LIKE 'EO.EUM.DAT.MFG%' OR id LIKE 'EO.EUM.DAT.MSG%'\"\n",
+    ").collection_list()\n",
+    "show(results, limit=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-md-not",
+   "metadata": {},
+   "source": [
+    "EUMETSAT collections that are **NOT** climate data records (`NOT`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "sec5-code-not",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "11 collections found\n",
+      "  EO.EUM.DAT.MSG.CLM  —  Cloud Mask - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.CLM-IODC  —  Cloud Mask - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.CTH  —  Cloud Top Height - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.CTH-IODC  —  Cloud Top Height - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.HRSEVIRI  —  High Rate SEVIRI Level 1.5 Image Data - MSG - 0 degree\n",
+      "  EO.EUM.DAT.MSG.HRSEVIRI-IODC  —  High Rate SEVIRI Level 1.5 Image Data - MSG - Indian Ocean\n",
+      "  EO.EUM.DAT.MSG.LSA-FRM  —  Fire Risk Map - Released Energy Based - MSG\n",
+      "  EO.EUM.DAT.MSG.LSA-LSTDE  —  Land Surface Temperature with Directional Effects - MSG\n",
+      "  EO.EUM.DAT.MSG.MSG15-RSS  —  Rapid Scan High Rate SEVIRI Level 1.5 Image Data - MSG\n",
+      "  EO.EUM.DAT.MSG.RSS-CLM  —  Rapid Scan Cloud Mask - MSG\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Using AND, NOT\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"id LIKE 'EO.EUM.DAT.MSG%' AND NOT title LIKE '%Climate Data Record%'\"\n",
+    ").collection_list()\n",
+    "show(results, limit=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec6-md",
+   "metadata": {},
+   "source": [
+    "## 5. Beyond `id` and `title`\n",
+    "\n",
+    "Filters are not limited to the ID and the title. Two more fields are useful for discovery:\n",
+    "\n",
+    "- `description` : the full descriptive text of the collection, good for technical terms that never appear in the title\n",
+    "- `keywords` : a list of thematic tags; `LIKE` matches if **any** keyword contains the pattern\n",
+    "\n",
+    "Note how the first example reuses the `AND` from section 3 to keep only EUMETSAT results. Other providers also mention scatterometers in their descriptions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "sec6-code-desc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 collections found\n",
+      "  EO.EUM.DAT.METOP.OSI-150-A  —  ASCAT L2 25 km Winds Data Record Release 1 - Metop\n",
+      "  EO.EUM.DAT.METOP.OSI-150-B  —  ASCAT L2 12.5 km Winds Data Record Release 1 - Metop\n",
+      "  EO.EUM.DAT.METOP.SOMO12  —  ASCAT Soil Moisture at 12.5 km Swath Grid in NRT - Metop\n",
+      "  EO.EUM.DAT.METOP.SOMO25  —  ASCAT Soil Moisture at 25 km Swath Grid in NRT - Metop\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Using a description over the id\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"id LIKE 'EO.EUM%' AND description LIKE '%scatterometer%'\"\n",
+    ").collection_list()\n",
+    "show(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "sec6-code-keywords",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6 collections found\n",
+      "  EO.EUM.CM.METOP.ASCSZFR02  —  ASCAT Level 1 SZF Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZOR02  —  ASCAT Level 1 SZO Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZRR02  —  ASCAT Level 1 SZR Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.DAT.METOP.MHSMWHS0200  —  MHS Microwave Humidity Sounder Climate Data Record Release 2 - Metop-A and -B\n",
+      "  EO.EUM.DAT.MSG.SEVIRI-RSS_HR_IMG-L1_5-V1  —  SEVIRI Rapid Scan High Rate Level 1.5 Image Data Climate Data Record Release 1 - MSG\n",
+      "  EO.EUM.DAT.MULT.MHSMWHS0100  —  MHS Microwave Humidity Sounder Climate Data Record Release 1 - Metop and NOAA\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Using a keyword over the topic\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"keywords LIKE '%Fundamental Climate Data Record%'\"\n",
+    ").collection_list()\n",
+    "show(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec7-md",
+   "metadata": {},
+   "source": [
+    "## 6. The same filter as JSON: `cql2-json`\n",
+    "\n",
+    "Everything so far used the text encoding. The JSON encoding expresses the same conditions as a plain Python dict, convenient when the filter is built programmatically ( to avoid going through a list of conditions), because there is no string quoting to get wrong.\n",
+    "\n",
+    "Pass the dict to `filter` and set `filter_lang=\"cql2-json\"` explicitly (without it, `pystac-client` tries to convert the dict to text and asks for an extra package).\n",
+    "\n",
+    "The filter below is identical to the `AND` example of section 6, so it returns the same collections:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "sec7-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "27 collections found\n",
+      "  EO.EUM.CM.METOP.ASCSZFR02  —  ASCAT Level 1 SZF Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZOR02  —  ASCAT Level 1 SZO Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.CM.METOP.ASCSZRR02  —  ASCAT Level 1 SZR Climate Data Record Release 2 - Metop\n",
+      "  EO.EUM.DAT.AMVR02  —  Atmospheric Motion Vectors Climate Data Record Release 2 - MFG and MSG - 0 degree\n",
+      "  EO.EUM.DAT.GSAL2R02  —  GSA Level 2 Climate Data Record Release 2 - MFG and MSG - 0 degree\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Using a dictionary\n",
+    "filter_json = {\n",
+    "    \"op\": \"and\",\n",
+    "    \"args\": [\n",
+    "        {\"op\": \"like\", \"args\": [{\"property\": \"id\"}, \"EO.EUM%\"]},\n",
+    "        {\"op\": \"like\", \"args\": [{\"property\": \"title\"}, \"%Climate%\"]},\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "results = catalog.collection_search(filter=filter_json, filter_lang=\"cql2-json\").collection_list()\n",
+    "show(results, limit=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec8-md",
+   "metadata": {},
+   "source": [
+    "## 7. Putting it all together\n",
+    "\n",
+    "A realistic search combining what we learned. Say we want **Atmospheric Motion Vectors derived from Meteosat Second Generation**:\n",
+    "\n",
+    "- we know the satellite family, so we anchor the ID with `LIKE 'EO.EUM.DAT.MSG%'`\n",
+    "- we are not sure how the product is capitalized in the title, so we use `CASEI()`\n",
+    "- both must hold, so we join them with `AND`\n",
+    "\n",
+    "The filter lands on exactly one collection, the ID we need for the next step, searching items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "sec8-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 collections found\n",
+      "  EO.EUM.DAT.MSG.SEVIRI-RSS_AMV-CDR-V1  —  SEVIRI Rapid Scan Atmospheric Motion Vectors Climate Data Record Release 1 - MSG\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Combining multiple operators (Like, AND, CASEI())\n",
+    "results = catalog.collection_search(\n",
+    "    filter=\"id LIKE 'EO.EUM.DAT.MSG%' AND CASEI(title) LIKE CASEI('%atmospheric motion vector%')\"\n",
+    ").collection_list()\n",
+    "show(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cbf1d31",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 collections found\n",
+      "  EO.EUM.DAT.SENTINEL-3.SR_2_WATBC005  —  SRAL Level 2 Altimetry Global (version BC005) - Sentinel-3 - Reprocessed\n",
+      "  EO.EUM.DAT.SENTINEL-3.SR_2_WAT___  —  SRAL Level 2 Altimetry Global - Sentinel-3\n"
+     ]
+    }
+   ],
+   "source": [
+    "#\n",
+    "f1 = (\n",
+    "    \"id LIKE 'EO.EUM%' \"                                # LIKE: EUM provider\n",
+    "    \"AND title LIKE '%Level 2%' \"                       # LIKE: Processing level\n",
+    "    \"AND CASEI(title) LIKE CASEI('%global%') \"          # CASEI: 'global'coverage\n",
+    "    \"AND NOT title LIKE '%Climate Data Record%'\"        # NOT: exclude climate data records\n",
+    ")\n",
+    "show(catalog.collection_search(filter=f1).collection_list(), limit=5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "f66b79c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4 collections found\n",
+      "  EO.EUM.DAT.METOP.OSI-150-A  —  ASCAT L2 25 km Winds Data Record Release 1 - Metop\n",
+      "  EO.EUM.DAT.METOP.OSI-150-B  —  ASCAT L2 12.5 km Winds Data Record Release 1 - Metop\n",
+      "  EO.EUM.DAT.SENTINEL-3.SR_2_WATBC005  —  SRAL Level 2 Altimetry Global (version BC005) - Sentinel-3 - Reprocessed\n",
+      "  EO.EUM.DAT.SENTINEL-3.SR_2_WAT___  —  SRAL Level 2 Altimetry Global - Sentinel-3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Same filter in cql2-json: explicit grouping, no parentheses involved.\n",
+    "# Returns the same wrong results, so the bug is in the query evaluation,\n",
+    "# not in the cql2-text parser.\n",
+    "filter_json = {\n",
+    "    \"op\": \"and\",\n",
+    "    \"args\": [\n",
+    "        {\"op\": \"like\", \"args\": [{\"property\": \"title\"}, \"%Global%\"]},\n",
+    "        {\"op\": \"or\", \"args\": [\n",
+    "            {\"op\": \"like\", \"args\": [{\"property\": \"title\"}, \"%Level 2%\"]},\n",
+    "            {\"op\": \"like\", \"args\": [{\"property\": \"title\"}, \"%L2%\"]},\n",
+    "        ]},\n",
+    "    ],\n",
+    "}\n",
+    "results = catalog.collection_search(filter=filter_json, filter_lang=\"cql2-json\").collection_list()\n",
+    "show(results, limit=30)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The Filter extension turns collection search into a precise query: pick the operator based on what you already know.\n",
+    "\n",
+    "| You know... | Use |\n",
+    "|---|---|\n",
+    "| The exact collection ID | `id = '...'` |\n",
+    "| Part of the ID or title | `LIKE` with `%` wildcards |\n",
+    "| The words, but not the casing | `CASEI(field) LIKE CASEI('...')` |\n",
+    "| A short list of IDs | `id IN (...)` |\n",
+    "| Several criteria at once | `AND`, `OR`, `NOT` |\n",
+    "| A technical term or a thematic tag | `description LIKE` / `keywords LIKE` |\n",
+    "| The filter is built by code | a dict + `filter_lang=\"cql2-json\"` |\n",
+    "\n",
+    "In every case the outcome is a **collection ID**  the key for the next step, searching and downloading items inside the collection.\n",
+    "The title is used for thematic search (descriptive keywords), and the id is used to filter by the catalog structure (provider, product family)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "resources",
+   "metadata": {},
+   "source": [
+    "## Resources and references\n",
+    "\n",
+    "- [STAC API Filter extension](https://github.com/stac-api-extensions/filter)\n",
+    "- [OGC Common Query Language (CQL2) standard](https://docs.ogc.org/is/21-065r2/21-065r2.html)\n",
+    "- [pystac-client documentation](https://pystac-client.readthedocs.io/)\n",
+    "- [DEDL documentation — Data Discovery](https://destine-data-lake-docs.data.destination-earth.eu/en/latest/dedl-discovery-and-data-access/Harmonized-Data-Access/API-Guide/Services-and-Data-Discovery.html)\n",
+    "- [DestinE Data Portfolio (web UI)](https://hda.data.destination-earth.eu/ui/catalog)\n",
+    "- [HDA-Dataset-Discovery.ipynb](HDA-Dataset-Discovery.ipynb) for the full discovery workflow (free text, providers, space and time)\n",
+    "- [HDA-PyStac-Client.ipynb](../HDA-PyStac-Client.ipynb) for item search and access"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geodeld",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
#### Summary

- Add `HDA-Dataset-Discovery-STAC-API-Filter-Extension.ipynb`: a notebook
  demonstrating dataset discovery on the HDA using the STAC API using the CQL2
  filter extension

## Notes

- Supersedes the closed PR #171, which accidentally included unrelated
  commits from the `hda_improvements` branch. This PR contains only the
  notebook.
