### PR TITLE
fix: update thumbnail path in HDA dataset discovery notebook

### DIFF
--- a/HDA/PySTAC/Data-Discovery/HDA-Dataset-Discovery-STAC-API-Filter-Extension.ipynb
+++ b/HDA/PySTAC/Data-Discovery/HDA-Dataset-Discovery-STAC-API-Filter-Extension.ipynb
@@ -11,7 +11,7 @@
     "\"\n",
     "author: \"Author: Alejandro Fonseca (EUMETSAT/Starion)\"\n",
     "tags: [HDA,STAC,CQL2]\n",
-    "thumbnail: img/EUMETSAT_TEST.png \n",
+    "thumbnail: ../../../img/STAC-01.png \n",
     "license: MIT\n",
     "copyright: \"© 2024 EUMETSAT\"\n",
     "---"


### PR DESCRIPTION
Updates the thumbnail path in the frontmatter of
HDA/PySTAC/Data-Discovery/HDA-Dataset-Discovery-STAC-API-Filter-Extension.ipynb
from the placeholder `img/EUMETSAT_TEST.png` to `../../../img/STAC-01.png`,
following the official documentation convention and other notebooks structure

No other changes to the notebook.
